### PR TITLE
ignore zero variance columns

### DIFF
--- a/src/GaussianNB.js
+++ b/src/GaussianNB.js
@@ -150,7 +150,7 @@ function calculateLogProbability(value, mean, C1, C2) {
     value = value - mean;
     var possibleDevisionBy0 = Math.log(C1 * Math.exp((value * value) / C2));
     if (Number.isNaN(possibleDevisionBy0) || !Number.isFinite(possibleDevisionBy0)) {
-        return Math.log(Number.MAX_VALUE)
+        return 0;
     }
     return possibleDevisionBy0;
 }

--- a/src/GaussianNB.js
+++ b/src/GaussianNB.js
@@ -148,5 +148,9 @@ function getCurrentClass(currentCase, mean, classes) {
  */
 function calculateLogProbability(value, mean, C1, C2) {
     value = value - mean;
-    return Math.log(C1 * Math.exp((value * value) / C2));
+    var possibleDevisionBy0 = Math.log(C1 * Math.exp((value * value) / C2));
+    if (Number.isNaN(possibleDevisionBy0) || !Number.isFinite(possibleDevisionBy0)) {
+        return Math.log(Number.MAX_VALUE)
+    }
+    return possibleDevisionBy0;
 }

--- a/src/__tests__/GaussianNB.js
+++ b/src/__tests__/GaussianNB.js
@@ -36,6 +36,54 @@ describe('Naive bayes', () => {
         expect(result).toEqual(predictions);
     });
 
+    test('single column clustering', () => {
+        var cases = [[1, 3],
+            [2, 5],
+            [3, 8],
+            [4, 10],
+            [5, 6],
+            [6, 11]];
+        var predictions = [0, 0, 1, 1, 0, 1];
+        var nb = new GaussianNB();
+        nb.train(cases, predictions);
+
+        var result = nb.predict([[10, 4], [0, 9]]);
+
+        expect(result).toEqual([0, 1]);
+    });
+
+    test('low deviation column', () => {
+        var cases = [[1.00001, 3],
+            [1.00001001, 5],
+            [1.00001, 8],
+            [1.00001002, 10],
+            [1.00001, 6],
+            [1.00001, 11]];
+        var predictions = [0, 0, 1, 1, 0, 1];
+        var nb = new GaussianNB();
+        nb.train(cases, predictions);
+
+        var result = nb.predict([[1, 4], [1, 9]]);
+
+        expect(result).toEqual([0, 1]);
+    });
+
+    test('zero deviation column', () => {
+        var cases = [[0, 3],
+            [0, 5],
+            [0, 8],
+            [0, 10],
+            [0, 6],
+            [0, 11]];
+        var predictions = [0, 0, 1, 1, 0, 1];
+        var nb = new GaussianNB();
+        nb.train(cases, predictions);
+
+        var result = nb.predict([[0, 4], [0, 9]]);
+
+        expect(result).toEqual([0, 1]);
+    });
+
     test('Export and import', () => {
         var cases = [[6, 148, 72, 35, 0, 33.6, 0.627, 5],
             [1.50, 85, 66.5, 29, 0, 26.6, 0.351, 31],


### PR DESCRIPTION
When processing arbitrary statistical data, it is possible that some columns just may have a very low variance for one or more classes being trained.
While it might be desirable to replace probability calculations with a sharp comparison, ignoring such columns at least does not break processing of the other columns (that's what currently happens, see tests).